### PR TITLE
fix issue with route flushing

### DIFF
--- a/ssbgp.py
+++ b/ssbgp.py
@@ -15,6 +15,7 @@
 # the License.
 
 import os
+import sys
 import time
 import yaml
 import argparse
@@ -90,7 +91,8 @@ def remove_prefixes(peer, announced_prefixes, remove_prefixes):
 
     for prefix in prefixes_to_withdraw:
         print 'neighbor {} withdraw route {} next-hop self'.format(peer, prefix)
-
+    sys.stdout.flush()
+        
     return announced_prefixes - prefixes_to_withdraw
 
 


### PR DESCRIPTION
If all the data on stdout are not flushed, ExaBGP will not be able to receive them until another write does cause it.
It result in people trying other workaround like sleeping like in https://github.com/Exa-Networks/exabgp/issues/682#issuecomment-443819051